### PR TITLE
feat(layout): added initial layout

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,5 @@
 // React Native
-import { View } from "react-native";
+import { Text, View } from "react-native";
 
 // Components
 import Header from "@/components/Header/Header";
@@ -19,12 +19,60 @@ export default function Home() {
   }, [navigation]);
 
   return (
-    <View className="flex-1 items-center justify-center bg-bg-light dark:bg-bg-dark">
-      <View className="flex-row justify-between border-2 border-red-900 w-full p-4">
-        <View className="flex-row items-center gap-x-2">
-          <Header crumbs={["Castle Stiel", "Access Screen"]} />
+    <View className="flex-1 bg-bg-light dark:bg-bg-dark">
+      {/* Column container: let children STRETCH, not center */}
+      <View className="flex-1 flex-col">
+        {/* Header */}
+        <View
+          style={{ flex: 0.5 }}
+          className="self-stretch border-2 border-red-900 p-4"
+        >
+          {/* Row: allow left/right to shrink within the row */}
+          <View className="flex-row items-center justify-between">
+            {/* Left side can grow/shrink; min-w-0 is the key to prevent overflow */}
+            <View className="flex-1 min-w-0">
+              <Header crumbs={["Castle Stiel", "Access Screen"]} />
+            </View>
+            {/* Right side toggle; prevent it from stretching the row */}
+            <View className="shrink-0">
+              <ThemeToggle />
+            </View>
+          </View>
         </View>
-        <ThemeToggle />
+
+        {/* Main */}
+        <View
+          style={{ flex: 7 }}
+          className="self-stretch border-2 border-red-700"
+        >
+          <View className="flex-1 items-center justify-center">
+            <Text className="text-text-light dark:text-text-dark text-2xl">
+              Main Play Area
+            </Text>
+          </View>
+        </View>
+
+        {/* Control Bar */}
+        <View
+          style={{ flex: 2 }}
+          className="self-stretch border-2 border-red-700"
+        >
+          <View className="flex-1 items-center justify-center">
+            <Text className="text-text-light dark:text-text-dark text-2xl">
+              Card Drive
+            </Text>
+          </View>
+        </View>
+
+        {/* Footer */}
+        <View
+          style={{ flex: 0.5 }}
+          className="self-stretch border-2 border-red-700"
+        >
+          <View className="flex-1 items-center justify-center">
+            <Text className="text-text-light dark:text-text-dark">FOOTER</Text>
+          </View>
+        </View>
       </View>
     </View>
   );

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -7,14 +7,14 @@ interface HeaderProps {
 
 export default function Header({ crumbs }: HeaderProps) {
   return (
-    <View className="flex-row items-center">
+    <View className="flex flex-row w-full items-start">
       {crumbs.map((crumb, index) => (
         <View key={index} className="flex-row items-center">
-          <Text className="text-text-light dark:text-text-dark text-2xl">
+          <Text className="text-text-light dark:text-text-dark text-xl">
             {crumb}
           </Text>
           {index < crumbs.length - 1 && (
-            <Text className="mx-2 text-text-light dark:text-text-dark text-2xl">
+            <Text className="mx-2 text-text-light dark:text-text-dark text-xl">
               {" » "}
             </Text>
           )}

--- a/components/ScreenLayout.tsx
+++ b/components/ScreenLayout.tsx
@@ -1,0 +1,54 @@
+// components/ScreenLayout.tsx
+import React from "react";
+import { SafeAreaView, View, ViewStyle } from "react-native";
+import Header from "./Header/Header";
+
+export type Size = number | `${number}%`; // dp or percentage
+type Props = {
+  headerHeight?: Size;
+  controlBarHeight?: Size;
+  footerHeight?: Size;
+  children?: React.ReactNode; // your Main View
+  header?: React.ReactNode;
+  controlBar?: React.ReactNode;
+  footer?: React.ReactNode;
+  style?: ViewStyle; // optional container overrides
+};
+
+export default function ScreenLayout({
+  headerHeight = 96,
+  controlBarHeight = 72,
+  footerHeight = 72,
+  header,
+  controlBar,
+  footer,
+  children,
+  style,
+}: Props) {
+  return (
+    <SafeAreaView className="flex-1 bg-bg-light dark:bg-bg-dark" style={style}>
+      <View className="flex-1 flex-col w-full">
+        {/* Header */}
+        <View
+          className="w-full border-2 border-solid border-red-500"
+          style={{ height: headerHeight }}
+        >
+          {header ?? <Header crumbs={["Home", "Details"]} />}
+        </View>
+
+        {/* Main (fills the rest) */}
+        <View className="flex-1 w-full min-h-0">{children}</View>
+
+        {/* Control Bar */}
+        <View className="w-full" style={{ height: controlBarHeight }}>
+          {controlBar}
+        </View>
+
+        {/* Footer */}
+        <View className="w-full" style={{ height: footerHeight }}>
+          {footer}
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}


### PR DESCRIPTION
This pull request refactors the main screen layout and header components to improve structure, flexibility, and maintainability. It introduces a new reusable `ScreenLayout` component and updates the `Header` and `Home` screen to use more flexible layouts and styling.

**Screen layout improvements:**

* Added a new `ScreenLayout` component (`components/ScreenLayout.tsx`) that provides a flexible, reusable structure for screens, with configurable header, control bar, footer, and main content areas. It supports custom heights and accepts custom React nodes for each section.
* Refactored the main `Home` screen (`app/index.tsx`) to use a column-based layout, separating the header, main play area, control bar, and footer, each with clear flex proportions and styling. The layout now stretches to fill the screen, improving responsiveness and organization.
* Updated imports in `app/index.tsx` to include `Text` from `react-native` for displaying section labels.

**Header component adjustments:**

* Modified the `Header` component (`components/Header/Header.tsx`) to use a more flexible layout, aligning items to the start and reducing text size for breadcrumbs and separators for a cleaner appearance.